### PR TITLE
changed styling of petclinic example box slightly

### DIFF
--- a/css/guides.css
+++ b/css/guides.css
@@ -340,10 +340,17 @@ pre.CodeRay {
 
 .example_cuba_petclinic-wrapper {
     border: 1px solid #e5e5e5;
+    background-color: #f7f7f7;
     position: relative;
     margin-top: 1em;
     margin-bottom: 1em;
+
+    border-radius: 3px;
+    -webkit-border-radius: 3px;
+    -moz-border-radius: 3px;
+    -o-border-radius: 3px;
 }
+
 
 #example_cuba_petclinic a {
     width: 100%;
@@ -369,10 +376,11 @@ pre.CodeRay {
 
 #example_cuba_petclinic {
     padding: 0;
+    border-bottom: 1px solid #e5e5e5;
 }
 
 .example_cuba_petclinic-wrapper .sectionbody {
-    padding: 0 25px 25px 25px;
+    padding: 15px 25px 25px 25px;
 }
 
 #example_cuba_petclinic a.link {


### PR DESCRIPTION
I was playing around a little bit. I think we should make the "Petclinic example" box of different color then the rest of the content.

Changing it to the regular grey style would look like this:

<img width="859" alt="bildschirmfoto 2019-01-25 um 18 54 52" src="https://user-images.githubusercontent.com/817400/51763407-d9c07300-20d2-11e9-9675-111391a24d9f.png">


WDYT?